### PR TITLE
Fix spelling in Logo constant

### DIFF
--- a/pkg/kubestr/kubestr.go
+++ b/pkg/kubestr/kubestr.go
@@ -28,7 +28,7 @@ const Logo = `
   | ' <| |_| | _ \ _|\__ \ | | |   /
   |_|\_\\___/|___/___|___/ |_| |_|_\
 
-Explore your kuberntes storage options
+Explore your kubernetes storage options
 **************************************
 `
 


### PR DESCRIPTION
Updated 'kuberntes' :arrow_right: 'kubernetes' in the Logo constant that shows when running kubestr.