### PR TITLE
Separate JSON output, emit non-zero exit code

### DIFF
--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -86,7 +86,7 @@ func init() {
 	rootCmd.AddCommand(fioCmd)
 	fioCmd.Flags().StringVarP(&storageClass, "storageclass", "s", "", "The name of a Storageclass. (Required)")
 	_ = fioCmd.MarkFlagRequired("storageclass")
-	fioCmd.Flags().StringVarP(&fioCheckerSize, "size", "z", fio.DefaultPVCSize, "The size of the volume used to run FIO.")
+	fioCmd.Flags().StringVarP(&fioCheckerSize, "size", "z", fio.DefaultPVCSize, "The size of the volume used to run FIO. Note that the FIO job definition is not scaled accordingly.")
 	fioCmd.Flags().StringVarP(&namespace, "namespace", "n", fio.DefaultNS, "The namespace used to run FIO.")
 	fioCmd.Flags().StringVarP(&fioCheckerFilePath, "fiofile", "f", "", "The path to a an fio config file.")
 	fioCmd.Flags().StringVarP(&fioCheckerTestName, "testname", "t", "", "The Name of a predefined kubestr fio test. Options(default-fio)")
@@ -146,6 +146,8 @@ func Baseline(ctx context.Context, output string) error {
 	return err
 }
 
+// PrintAndJsonOutput Print JSON output to stdout and to file if arguments say so
+// Returns whether something was printed out or not
 func PrintAndJsonOutput(result []*kubestr.TestOutput, output string, outfile string) bool {
 	if output == "json" {
 		jsonRes, _ := json.MarshalIndent(result, "", "    ")

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -154,7 +154,8 @@ func PrintAndJsonOutput(result []*kubestr.TestOutput, output string, outfile str
 		if len(outfile) > 0 {
 			err := os.WriteFile(outfile, jsonRes, 0666)
 			if err != nil {
-				return true
+				fmt.Println("Error writing output:", err.Error())
+				os.Exit(2)
 			}
 		} else {
 			fmt.Println(string(jsonRes))

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -117,11 +117,9 @@ func Baseline(ctx context.Context, output string) {
 	}
 	fmt.Print(kubestr.Logo)
 	result := p.KubernetesChecks()
-	if output == "json" {
-		jsonRes, _ := json.MarshalIndent(result, "", "    ")
-		fmt.Println(string(jsonRes))
-		return
-	}
+
+	PrintAndJsonOutput(result, output, outfile)
+
 	for _, retval := range result {
 		retval.Print()
 		fmt.Println()
@@ -133,11 +131,7 @@ func Baseline(ctx context.Context, output string) {
 		fmt.Println(err.Error())
 		return
 	}
-	if output == "json" {
-		jsonRes, _ := json.MarshalIndent(result, "", "    ")
-		fmt.Println(string(jsonRes))
-		return
-	}
+
 	fmt.Println("Available Storage Provisioners:")
 	fmt.Println()
 	time.Sleep(500 * time.Millisecond) // Added to introduce lag.
@@ -148,7 +142,7 @@ func Baseline(ctx context.Context, output string) {
 	}
 }
 
-func PrintAndJsonOutput(result *kubestr.TestOutput, output string, outfile string) {
+func PrintAndJsonOutput(result []*kubestr.TestOutput, output string, outfile string) {
 	if output == "json" {
 		jsonRes, _ := json.MarshalIndent(result, "", "    ")
 		if len(outfile) > 0 {
@@ -187,8 +181,8 @@ func Fio(ctx context.Context, output, outfile, storageclass, size, namespace, jo
 	} else {
 		result = kubestr.MakeTestOutput(testName, kubestr.StatusOK, fmt.Sprintf("\n%s", fioResult.Result.Print()), fioResult)
 	}
-
-	PrintAndJsonOutput(result, output, outfile)
+	var result_ = []*kubestr.TestOutput{result}
+	PrintAndJsonOutput(result_, output, outfile)
 	result.Print()
 }
 
@@ -232,6 +226,7 @@ func CSICheck(ctx context.Context, output, outfile,
 		result = kubestr.MakeTestOutput(testName, kubestr.StatusOK, "CSI application successfully snapshotted and restored.", csiCheckResult)
 	}
 
-	PrintAndJsonOutput(result, output, outfile)
+	var result_ = []*kubestr.TestOutput{result}
+	PrintAndJsonOutput(result_, output, outfile)
 	result.Print()
 }

--- a/main.go
+++ b/main.go
@@ -18,10 +18,13 @@ package main
 
 import (
 	"github.com/kastenhq/kubestr/cmd"
+	"os"
 )
 
 func main() {
-	_ = Execute()
+	if err := Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 // Execute executes the main command


### PR DESCRIPTION
Address issues #79 and #80 to make kubestr a better citizen in scripted usage.