### PR TITLE
Add a node parameter to the FIO benchmark

### DIFF
--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -46,6 +46,7 @@ var (
 	namespace      string
 	containerImage string
 
+	fioNode            string
 	fioCheckerSize     string
 	fioCheckerFilePath string
 	fioCheckerTestName string
@@ -56,7 +57,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
-			Fio(ctx, output, storageClass, fioCheckerSize, namespace, fioCheckerTestName, fioCheckerFilePath, containerImage)
+			Fio(ctx, output, storageClass, fioCheckerSize, namespace, fioCheckerTestName, fioCheckerFilePath, containerImage, fioNode)
 		},
 	}
 
@@ -87,6 +88,7 @@ func init() {
 	fioCmd.Flags().StringVarP(&fioCheckerFilePath, "fiofile", "f", "", "The path to a an fio config file.")
 	fioCmd.Flags().StringVarP(&fioCheckerTestName, "testname", "t", "", "The Name of a predefined kubestr fio test. Options(default-fio)")
 	fioCmd.Flags().StringVarP(&containerImage, "image", "i", "", "The container image used to create a pod.")
+	fioCmd.Flags().StringVarP(&fioNode, "node", "N", "", "The name of the node on which the pod is deployed.")
 
 	rootCmd.AddCommand(csiCheckCmd)
 	csiCheckCmd.Flags().StringVarP(&storageClass, "storageclass", "s", "", "The name of a Storageclass. (Required)")
@@ -146,7 +148,7 @@ func Baseline(ctx context.Context, output string) {
 }
 
 // Fio executes the FIO test.
-func Fio(ctx context.Context, output, storageclass, size, namespace, jobName, fioFilePath string, containerImage string) {
+func Fio(ctx context.Context, output, storageclass, size, namespace, jobName, fioFilePath string, containerImage string, node string) {
 	cli, err := kubestr.LoadKubeCli()
 	if err != nil {
 		fmt.Println(err.Error())
@@ -164,6 +166,7 @@ func Fio(ctx context.Context, output, storageclass, size, namespace, jobName, fi
 		FIOJobName:     jobName,
 		FIOJobFilepath: fioFilePath,
 		Image:          containerImage,
+		Node:           node,
 	}); err != nil {
 		result = kubestr.MakeTestOutput(testName, kubestr.StatusError, err.Error(), fioResult)
 	} else {


### PR DESCRIPTION
I've added a parameter to the FIO benchmark which allows to specify a node on which to deploy the pod which runs the benchmark. Internally it sets the *Node* field in the Pod definition. The notation is `--node` or `-N` and the default value is empty, meaning no node is specified.

Examples of when setting a specific node matters:
- Unequal connectivity bandwidth to nodes in the cluster.
- Benchmarking on nodes which do not contain privisioned storage.
- Keeping the same conditions when repeating benchmarks or trying different FIO configurations.