### PR TITLE
Update CI Linter To Download Deps

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,10 +12,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1.14
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.42
-          args: --timeout=5m
+          version: v1.46
+          args: --timeout=5m --modules-download-mode=mod


### PR DESCRIPTION
This PR fixes [some CI linter issues](https://github.com/kastenhq/kubestr/actions/runs/2569879529) caused by missing vendored dependencies, by updating the `golangci-lint` config to download dependencies.

The most-recent CI job result with this fix can be found [here](https://github.com/kastenhq/kubestr/actions/runs/2571530092).

Signed-off-by: Ivan Sim <ivan.sim@kasten.io>