### PR TITLE
Enforce that no arguments can be passed to commands that do not use any

### DIFF
--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -38,6 +38,7 @@ var (
 		and validate that the storage systems in place as well as run
 		performance tests.`,
 		SilenceUsage: true,
+		Args:         cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
@@ -56,6 +57,7 @@ var (
 		Use:   "fio",
 		Short: "Runs an fio test",
 		Long:  `Run an fio test`,
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
@@ -71,6 +73,7 @@ var (
 		Use:   "csicheck",
 		Short: "Runs the CSI snapshot restore check",
 		Long:  "Validates a CSI provisioners ability to take a snapshot of an application and restore it",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -85,8 +85,8 @@ var (
 	pvcBrowseCmd       = &cobra.Command{
 		Use:   "browse [PVC name]",
 		Short: "Browse the contents of a CSI PVC via file browser",
-		Args:  cobra.ExactArgs(1),
 		Long:  "Browse the contents of a CSI provisioned PVC by cloning the volume and mounting it with a file browser.",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return CsiPvcBrowse(context.Background(), args[0],
 				namespace,


### PR DESCRIPTION
Kubestr currently silently ignores unnecessary arguments that are passed to commands that do not use any. I have changed the behaviour to enforce that no arguments can be passed to these commands.

The reason is to prevent user errors that come from accidentally using unescaped space characters. In particular ( #105 ):
```-N key=value, foo=bar```
instead of
```-N key=value,foo=bar```
would be uncaught without this change.