### PR TITLE
Pin Go Version Used By CI Linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: 1.17
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.46
+          version: v1.48
           args: --timeout=5m --modules-download-mode=mod

--- a/pkg/fio/fio.go
+++ b/pkg/fio/fio.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -189,7 +189,7 @@ func (s *fioStepper) loadConfigMap(ctx context.Context, args *RunFIOArgs) (*v1.C
 	}
 	switch {
 	case args.FIOJobFilepath != "":
-		data, err := ioutil.ReadFile(args.FIOJobFilepath)
+		data, err := os.ReadFile(args.FIOJobFilepath)
 		if err != nil {
 			return nil, errors.Wrap(err, "File reading error")
 		}

--- a/pkg/fio/fio_test.go
+++ b/pkg/fio/fio_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -382,7 +381,7 @@ func (s *FIOTestSuite) TestValidateNamespace(c *C) {
 
 func (s *FIOTestSuite) TestLoadConfigMap(c *C) {
 	ctx := context.Background()
-	file, err := ioutil.TempFile("", "tempTLCfile")
+	file, err := os.CreateTemp("", "tempTLCfile")
 	c.Check(err, IsNil)
 	defer os.Remove(file.Name())
 	for i, tc := range []struct {


### PR DESCRIPTION
This PR pins the Go version used by the golangci-linter action to ensure it matches that defined in go.mod. It also upgrades the golangci-lint to the latest version.

Signed-off-by: Ivan Sim <ivan.sim@kasten.io>