### PR TITLE
Update goreleaser CI job with 'write' permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ jobs:
   goreleaser:
     name: Release Go Binary
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
This PR updates the goreleaser CI job with the `write` permission to publish release artifacts to GH. The latest goreleaser GHA plugin failed with a 403 error, as seen [here](https://github.com/kastenhq/kubestr/runs/8002927255?check_suite_focus=true). See doc [here](https://goreleaser.com/ci/actions/#token-permissions). Also, related to https://github.com/goreleaser/goreleaser/issues/2642.

Signed-off-by: Ivan Sim <ivan.sim@kasten.io>