### PR TITLE
chore(deps): upgrade golangci-lint to v1.54.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,6 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.48
+          version: v1.54.2
           args: --timeout=5m --modules-download-mode=mod
           skip-pkg-cache: true


### PR DESCRIPTION
Release notes:
- https://github.com/golangci/golangci-lint/releases/tag/v1.54.2
- https://github.com/golangci/golangci-lint/releases