### PR TITLE
feat: Container image updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.18 AS builder
+FROM golang:1.21.6-alpine3.19 AS builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
@@ -17,7 +17,7 @@ COPY . .
 
 RUN go install -ldflags="-w -s" .
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 RUN apk --no-cache add fio
 


### PR DESCRIPTION
- Builder image moved to go 1.21 as per go.mod
- Runtime image upgraded to alpine 3.19

Hopefully fixes #218.

I ran this locally using:

```shell
docker build -t kubestr:local .
kind create cluster --name kubestr
kind load docker-image kubestr:local --name kubestr
go build .
./kubestr fio -n default -s standard -z "10Gi" --image kubestr:local
# and scanned
trivy image kubestr:local
```

Output:

```log
2024-01-31T09:46:29.777Z	INFO	Vulnerability scanning is enabled
2024-01-31T09:46:29.777Z	INFO	Secret scanning is enabled
2024-01-31T09:46:29.777Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-31T09:46:29.777Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-01-31T09:46:29.779Z	INFO	Detected OS: alpine
2024-01-31T09:46:29.779Z	WARN	This OS version is not on the EOL list: alpine 3.19
2024-01-31T09:46:29.779Z	INFO	Detecting Alpine vulnerabilities...
2024-01-31T09:46:29.780Z	INFO	Number of language-specific files: 1
2024-01-31T09:46:29.780Z	INFO	Detecting gobinary vulnerabilities...

kubestr:local (alpine 3.19.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

So in theory running a new build and updating the base images removes all known vulns for trivy.