### PR TITLE
Github Actions: set top level permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,8 @@
 name: Docker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   release:
     types:


### PR DESCRIPTION
There's the recommendation to set top level permission e.g. by setting `contents: read` and settings needed write permissions (already there) at the job level