### PR TITLE
Updating CreatePodArgs to consume PVC args in []string{} format instead of string

### DIFF
--- a/pkg/block/block_mount.go
+++ b/pkg/block/block_mount.go
@@ -133,13 +133,13 @@ func (b *blockMountChecker) Mount(ctx context.Context) (*BlockMountCheckerResult
 	tB = time.Now()
 	_, err = b.appCreator.CreatePod(ctx, &types.CreatePodArgs{
 		Name:           b.podName,
-		PVCName:        b.pvcName,
+		PVCName:        []string{b.pvcName},
 		Namespace:      b.args.Namespace,
 		RunAsUser:      b.args.RunAsUser,
 		ContainerImage: b.args.ContainerImage,
 		Command:        []string{"/bin/sh"},
 		ContainerArgs:  []string{"-c", "tail -f /dev/null"},
-		DevicePath:     "/mnt/block",
+		DevicePath:     []string{"/mnt/block"},
 	})
 	if err != nil {
 		fmt.Printf(" -> Failed to create Pod (%v)\n", err)

--- a/pkg/block/block_mount_test.go
+++ b/pkg/block/block_mount_test.go
@@ -299,13 +299,13 @@ func TestBlockMountCheckerMount(t *testing.T) {
 	createPodArgs := func(b *blockMountChecker) *types.CreatePodArgs {
 		return &types.CreatePodArgs{
 			Name:           b.podName,
-			PVCName:        b.pvcName,
+			PVCName:        []string{b.pvcName},
 			Namespace:      b.args.Namespace,
 			RunAsUser:      b.args.RunAsUser,
 			ContainerImage: b.args.ContainerImage,
 			Command:        []string{"/bin/sh"},
 			ContainerArgs:  []string{"-c", "tail -f /dev/null"},
-			DevicePath:     "/mnt/block",
+			DevicePath:     []string{"/mnt/block"},
 		}
 	}
 	createPod := func(b *blockMountChecker) *v1.Pod {

--- a/pkg/csi/csi_ops.go
+++ b/pkg/csi/csi_ops.go
@@ -208,27 +208,28 @@ func (c *applicationCreate) CreatePod(ctx context.Context, args *types.CreatePod
 				Command: args.Command,
 				Args:    args.ContainerArgs,
 			}},
-			Volumes: []v1.Volume{{
-				Name: volumeNameInPod,
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-						ClaimName: args.PVCName,
-					},
-				}},
-			},
 		},
 	}
-
-	if args.MountPath != "" {
-		pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{{
-			Name:      volumeNameInPod,
-			MountPath: args.MountPath,
-		}}
-	} else { // args.DevicePath
-		pod.Spec.Containers[0].VolumeDevices = []v1.VolumeDevice{{
-			Name:       volumeNameInPod,
-			DevicePath: args.DevicePath,
-		}}
+	for index, pvcName := range args.PVCName {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			Name: fmt.Sprintf("%s-%d", volumeNameInPod, index),
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvcName,
+				},
+			},
+		})
+		if len(args.MountPath) != 0 {
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
+				Name:      fmt.Sprintf("%s-%d", volumeNameInPod, index),
+				MountPath: args.MountPath[index],
+			})
+		} else { // args.DevicePath
+			pod.Spec.Containers[0].VolumeDevices = append(pod.Spec.Containers[0].VolumeDevices, v1.VolumeDevice{
+				Name:       fmt.Sprintf("%s-%d", volumeNameInPod, index),
+				DevicePath: args.DevicePath[index],
+			})
+		}
 	}
 
 	if args.RunAsUser > 0 {

--- a/pkg/csi/csi_ops_test.go
+++ b/pkg/csi/csi_ops_test.go
@@ -517,12 +517,12 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName:   "name",
-				PVCName:        "pvcname",
+				PVCName:        []string{"pvcname"},
 				Namespace:      "ns",
 				Command:        []string{"somecommand"},
 				RunAsUser:      1000,
 				ContainerImage: "containerimage",
-				MountPath:      "/mnt/fs",
+				MountPath:      []string{"/mnt/fs"},
 			},
 			errChecker: IsNil,
 			podChecker: NotNil,
@@ -532,10 +532,10 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName: "name",
-				PVCName:      "pvcname",
+				PVCName:      []string{"pvcname"},
 				Namespace:    "ns",
 				Command:      []string{"somecommand"},
-				MountPath:    "/mnt/fs",
+				MountPath:    []string{"/mnt/fs"},
 			},
 			failCreates: true,
 			errChecker:  NotNil,
@@ -546,10 +546,10 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName: "",
-				PVCName:      "pvcname",
+				PVCName:      []string{"pvcname"},
 				Namespace:    "ns",
 				Command:      []string{"somecommand"},
-				MountPath:    "/mnt/fs",
+				MountPath:    []string{"/mnt/fs"},
 			},
 			errChecker: NotNil,
 			podChecker: IsNil,
@@ -560,10 +560,10 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			args: &types.CreatePodArgs{
 				GenerateName: "name",
 				Name:         "name",
-				PVCName:      "pvcname",
+				PVCName:      []string{"pvcname"},
 				Namespace:    "ns",
 				Command:      []string{"somecommand"},
-				MountPath:    "/mnt/fs",
+				MountPath:    []string{"/mnt/fs"},
 			},
 			errChecker: NotNil,
 			podChecker: IsNil,
@@ -573,7 +573,7 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName: "name",
-				PVCName:      "",
+				PVCName:      []string{""},
 				Namespace:    "ns",
 				Command:      []string{"somecommand"},
 			},
@@ -585,11 +585,11 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName: "name",
-				PVCName:      "",
+				PVCName:      []string{""},
 				Namespace:    "ns",
 				Command:      []string{"somecommand"},
-				MountPath:    "/mnt/fs",
-				DevicePath:   "/mnt/dev",
+				MountPath:    []string{"/mnt/fs"},
+				DevicePath:   []string{"/mnt/dev"},
 			},
 			errChecker: NotNil,
 			podChecker: IsNil,
@@ -599,10 +599,10 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName: "name",
-				PVCName:      "",
+				PVCName:      []string{},
 				Namespace:    "ns",
 				Command:      []string{"somecommand"},
-				MountPath:    "/mnt/fs",
+				MountPath:    []string{"/mnt/fs"},
 			},
 			errChecker: NotNil,
 			podChecker: IsNil,
@@ -612,10 +612,10 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName: "name",
-				PVCName:      "pvcname",
+				PVCName:      []string{"pvcname"},
 				Namespace:    "",
 				Command:      []string{"somecommand"},
-				MountPath:    "/mnt/fs",
+				MountPath:    []string{"/mnt/fs"},
 			},
 			errChecker: NotNil,
 			podChecker: IsNil,
@@ -625,10 +625,10 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				GenerateName: "name",
-				PVCName:      "pvcname",
+				PVCName:      []string{"pvcname"},
 				Namespace:    "ns",
 				Command:      []string{"somecommand"},
-				MountPath:    "/mnt/fs",
+				MountPath:    []string{"/mnt/fs"},
 			},
 			errChecker: IsNil,
 			podChecker: NotNil,
@@ -638,10 +638,10 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			cli:         fake.NewSimpleClientset(),
 			args: &types.CreatePodArgs{
 				Name:       "name",
-				PVCName:    "pvcname",
+				PVCName:    []string{"pvcname"},
 				Namespace:  "ns",
 				Command:    []string{"somecommand"},
-				DevicePath: "/mnt/dev",
+				DevicePath: []string{"/mnt/dev"},
 			},
 			errChecker: IsNil,
 			podChecker: NotNil,
@@ -678,27 +678,29 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			c.Assert(len(pod.Spec.Containers), Equals, 1)
 			c.Assert(pod.Spec.Containers[0].Command, DeepEquals, tc.args.Command)
 			c.Assert(pod.Spec.Containers[0].Args, DeepEquals, tc.args.ContainerArgs)
-			if tc.args.MountPath != "" {
-				c.Assert(pod.Spec.Containers[0].VolumeMounts, DeepEquals, []v1.VolumeMount{{
-					Name:      "persistent-storage",
-					MountPath: tc.args.MountPath,
-				}})
-				c.Assert(pod.Spec.Containers[0].VolumeDevices, IsNil)
-			} else {
-				c.Assert(pod.Spec.Containers[0].VolumeDevices, DeepEquals, []v1.VolumeDevice{{
-					Name:       "persistent-storage",
-					DevicePath: tc.args.DevicePath,
-				}})
-				c.Assert(pod.Spec.Containers[0].VolumeMounts, IsNil)
-			}
-			c.Assert(pod.Spec.Volumes, DeepEquals, []v1.Volume{{
-				Name: "persistent-storage",
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-						ClaimName: tc.args.PVCName,
+			for index, pvcName := range tc.args.PVCName {
+				if len(tc.args.MountPath) != 0 {
+					c.Assert(pod.Spec.Containers[0].VolumeMounts[index], DeepEquals, v1.VolumeMount{
+						Name:      fmt.Sprintf("persistent-storage-%d", index),
+						MountPath: tc.args.MountPath[index],
+					})
+					c.Assert(pod.Spec.Containers[0].VolumeDevices, IsNil)
+				} else {
+					c.Assert(pod.Spec.Containers[0].VolumeDevices[index], DeepEquals, v1.VolumeDevice{
+						Name:       fmt.Sprintf("persistent-storage-%d", index),
+						DevicePath: tc.args.DevicePath[index],
+					})
+					c.Assert(pod.Spec.Containers[0].VolumeMounts, IsNil)
+				}
+				c.Assert(pod.Spec.Volumes[index], DeepEquals, v1.Volume{
+					Name: fmt.Sprintf("persistent-storage-%d", index),
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
 					},
-				}},
-			})
+				})
+			}
 			if tc.args.ContainerImage == "" {
 				c.Assert(pod.Spec.Containers[0].Image, Equals, common.DefaultPodImage)
 			} else {

--- a/pkg/csi/pvc_inspector.go
+++ b/pkg/csi/pvc_inspector.go
@@ -209,23 +209,23 @@ func (p *pvcBrowserSteps) CreateInspectorApplication(ctx context.Context, args *
 	}
 	podArgs := &types.CreatePodArgs{
 		GenerateName:   clonedPodGenerateName,
-		PVCName:        pvc.Name,
+		PVCName:        []string{pvc.Name},
 		Namespace:      args.Namespace,
 		RunAsUser:      args.RunAsUser,
 		ContainerImage: "filebrowser/filebrowser:v2",
 		ContainerArgs:  []string{"--noauth", "-r", "/pvc-data"},
-		MountPath:      "/pvc-data",
+		MountPath:      []string{"/pvc-data"},
 	}
 	if args.ShowTree {
 		podArgs = &types.CreatePodArgs{
 			GenerateName:   clonedPodGenerateName,
-			PVCName:        pvc.Name,
+			PVCName:        []string{pvc.Name},
 			Namespace:      args.Namespace,
 			RunAsUser:      args.RunAsUser,
 			ContainerImage: "alpine:3.19",
 			Command:        []string{"/bin/sh"},
 			ContainerArgs:  []string{"-c", "while true; do sleep 3600; done"},
-			MountPath:      "/pvc-data",
+			MountPath:      []string{"/pvc-data"},
 		}
 	}
 	pod, err := p.createAppOps.CreatePod(ctx, podArgs)

--- a/pkg/csi/pvc_inspector_steps_test.go
+++ b/pkg/csi/pvc_inspector_steps_test.go
@@ -539,10 +539,10 @@ func (s *CSITestSuite) TestCreateInspectorApplicationForPVC(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   clonedPodGenerateName,
-						PVCName:        "pvc1",
+						PVCName:        []string{"pvc1"},
 						Namespace:      "ns",
 						ContainerArgs:  []string{"--noauth", "-r", "/pvc-data"},
-						MountPath:      "/pvc-data",
+						MountPath:      []string{"/pvc-data"},
 						RunAsUser:      100,
 						ContainerImage: "filebrowser/filebrowser:v2",
 					}).Return(&v1.Pod{
@@ -594,10 +594,10 @@ func (s *CSITestSuite) TestCreateInspectorApplicationForPVC(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   clonedPodGenerateName,
-						PVCName:        "pvc1",
+						PVCName:        []string{"pvc1"},
 						Namespace:      "ns",
 						ContainerArgs:  []string{"--noauth", "-r", "/pvc-data"},
-						MountPath:      "/pvc-data",
+						MountPath:      []string{"/pvc-data"},
 						RunAsUser:      100,
 						ContainerImage: "filebrowser/filebrowser:v2",
 					}).Return(&v1.Pod{

--- a/pkg/csi/snapshot_inspector.go
+++ b/pkg/csi/snapshot_inspector.go
@@ -177,23 +177,23 @@ func (s *snapshotBrowserSteps) CreateInspectorApplication(ctx context.Context, a
 	}
 	podArgs := &types.CreatePodArgs{
 		GenerateName:   clonedPodGenerateName,
-		PVCName:        pvc.Name,
+		PVCName:        []string{pvc.Name},
 		Namespace:      args.Namespace,
 		RunAsUser:      args.RunAsUser,
 		ContainerImage: "filebrowser/filebrowser:v2",
 		ContainerArgs:  []string{"--noauth", "-r", "/snapshot-data"},
-		MountPath:      "/snapshot-data",
+		MountPath:      []string{"/snapshot-data"},
 	}
 	if args.ShowTree {
 		podArgs = &types.CreatePodArgs{
 			GenerateName:   clonedPodGenerateName,
-			PVCName:        pvc.Name,
+			PVCName:        []string{pvc.Name},
 			Namespace:      args.Namespace,
 			RunAsUser:      args.RunAsUser,
 			ContainerImage: "alpine:3.19",
 			Command:        []string{"/bin/sh"},
 			ContainerArgs:  []string{"-c", "while true; do sleep 3600; done"},
-			MountPath:      "/snapshot-data",
+			MountPath:      []string{"/snapshot-data"},
 		}
 	}
 	pod, err := s.createAppOps.CreatePod(ctx, podArgs)

--- a/pkg/csi/snapshot_inspector_steps_test.go
+++ b/pkg/csi/snapshot_inspector_steps_test.go
@@ -343,10 +343,10 @@ func (s *CSITestSuite) TestCreateInspectorApplicationForSnapshot(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   clonedPodGenerateName,
-						PVCName:        "pvc",
+						PVCName:        []string{"pvc"},
 						Namespace:      "ns",
 						ContainerArgs:  []string{"--noauth", "-r", "/snapshot-data"},
-						MountPath:      "/snapshot-data",
+						MountPath:      []string{"/snapshot-data"},
 						RunAsUser:      100,
 						ContainerImage: "filebrowser/filebrowser:v2",
 					}).Return(&v1.Pod{
@@ -398,10 +398,10 @@ func (s *CSITestSuite) TestCreateInspectorApplicationForSnapshot(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   clonedPodGenerateName,
-						PVCName:        "pvc",
+						PVCName:        []string{"pvc"},
 						Namespace:      "ns",
 						ContainerArgs:  []string{"--noauth", "-r", "/snapshot-data"},
-						MountPath:      "/snapshot-data",
+						MountPath:      []string{"/snapshot-data"},
 						RunAsUser:      100,
 						ContainerImage: "filebrowser/filebrowser:v2",
 					}).Return(&v1.Pod{

--- a/pkg/csi/snapshot_restore.go
+++ b/pkg/csi/snapshot_restore.go
@@ -48,7 +48,7 @@ func (r *SnapshotRestoreRunner) RunSnapshotRestore(ctx context.Context, args *ty
 			kubeCli: r.KubeCli,
 		},
 		createAppOps: &applicationCreate{
-			kubeCli: r.KubeCli,
+			kubeCli:               r.KubeCli,
 			k8sObjectReadyTimeout: args.K8sObjectReadyTimeout,
 		},
 		dataValidatorOps: &validateData{
@@ -179,13 +179,13 @@ func (s *snapshotRestoreSteps) CreateApplication(ctx context.Context, args *type
 	}
 	podArgs := &types.CreatePodArgs{
 		GenerateName:   originalPodGenerateName,
-		PVCName:        pvc.Name,
+		PVCName:        []string{pvc.Name},
 		Namespace:      args.Namespace,
 		RunAsUser:      args.RunAsUser,
 		ContainerImage: args.ContainerImage,
 		Command:        []string{"/bin/sh"},
 		ContainerArgs:  []string{"-c", fmt.Sprintf("echo '%s' >> /data/out.txt; sync; tail -f /dev/null", genString)},
-		MountPath:      "/data",
+		MountPath:      []string{"/data"},
 	}
 	pod, err := s.createAppOps.CreatePod(ctx, podArgs)
 	if err != nil {
@@ -262,13 +262,13 @@ func (s *snapshotRestoreSteps) RestoreApplication(ctx context.Context, args *typ
 	}
 	podArgs := &types.CreatePodArgs{
 		GenerateName:   clonedPodGenerateName,
-		PVCName:        pvc.Name,
+		PVCName:        []string{pvc.Name},
 		Namespace:      args.Namespace,
 		RunAsUser:      args.RunAsUser,
 		ContainerImage: args.ContainerImage,
 		Command:        []string{"/bin/sh"},
 		ContainerArgs:  []string{"-c", "tail -f /dev/null"},
-		MountPath:      "/data",
+		MountPath:      []string{"/data"},
 	}
 	pod, err := s.createAppOps.CreatePod(ctx, podArgs)
 	if err != nil {

--- a/pkg/csi/snapshot_restore_steps_test.go
+++ b/pkg/csi/snapshot_restore_steps_test.go
@@ -230,13 +230,13 @@ func (s *CSITestSuite) TestCreateApplication(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   originalPodGenerateName,
-						PVCName:        "pvc1",
+						PVCName:        []string{"pvc1"},
 						Namespace:      "ns",
 						Command:        []string{"/bin/sh"},
 						ContainerArgs:  []string{"-c", "echo 'some string' >> /data/out.txt; sync; tail -f /dev/null"},
 						RunAsUser:      100,
 						ContainerImage: "image",
-						MountPath:      "/data",
+						MountPath:      []string{"/data"},
 					}).Return(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "pod1",
@@ -271,13 +271,13 @@ func (s *CSITestSuite) TestCreateApplication(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   originalPodGenerateName,
-						PVCName:        "pvc1",
+						PVCName:        []string{"pvc1"},
 						Namespace:      "ns",
 						Command:        []string{"/bin/sh"},
 						ContainerArgs:  []string{"-c", "echo 'some string' >> /data/out.txt; sync; tail -f /dev/null"},
 						RunAsUser:      100,
 						ContainerImage: "image",
-						MountPath:      "/data",
+						MountPath:      []string{"/data"},
 					}).Return(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "pod1",
@@ -351,13 +351,13 @@ func (s *CSITestSuite) TestCreateApplication(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   originalPodGenerateName,
-						PVCName:        "pvc1",
+						PVCName:        []string{"pvc1"},
 						Namespace:      "ns",
 						Command:        []string{"/bin/sh"},
 						ContainerArgs:  []string{"-c", "echo 'some string' >> /data/out.txt; sync; tail -f /dev/null"},
 						RunAsUser:      100,
 						ContainerImage: "image",
-						MountPath:      "/data",
+						MountPath:      []string{"/data"},
 					}).Return(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "pod1",
@@ -618,11 +618,11 @@ func (s *CSITestSuite) TestRestoreApplication(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   clonedPodGenerateName,
-						PVCName:        "pvc1",
+						PVCName:        []string{"pvc1"},
 						Namespace:      "ns",
 						Command:        []string{"/bin/sh"},
 						ContainerArgs:  []string{"-c", "tail -f /dev/null"},
-						MountPath:      "/data",
+						MountPath:      []string{"/data"},
 						RunAsUser:      100,
 						ContainerImage: "image",
 					}).Return(&v1.Pod{
@@ -672,11 +672,11 @@ func (s *CSITestSuite) TestRestoreApplication(c *C) {
 					}, nil),
 					f.createAppOps.EXPECT().CreatePod(gomock.Any(), &types.CreatePodArgs{
 						GenerateName:   clonedPodGenerateName,
-						PVCName:        "pvc1",
+						PVCName:        []string{"pvc1"},
 						Namespace:      "ns",
 						Command:        []string{"/bin/sh"},
 						ContainerArgs:  []string{"-c", "tail -f /dev/null"},
-						MountPath:      "/data",
+						MountPath:      []string{"/data"},
 						RunAsUser:      100,
 						ContainerImage: "image",
 					}).Return(&v1.Pod{

--- a/pkg/csi/types/csi_types.go
+++ b/pkg/csi/types/csi_types.go
@@ -59,22 +59,22 @@ func (c *CreatePVCArgs) Validate() error {
 type CreatePodArgs struct {
 	Name           string // Only one of Name or
 	GenerateName   string // GenerateName should be specified.
-	PVCName        string
+	PVCName        []string
 	Namespace      string
 	RunAsUser      int64
 	ContainerImage string
 	Command        []string
 	ContainerArgs  []string
-	MountPath      string // Only one of MountPath or
-	DevicePath     string // DevicePath should be specified.
+	MountPath      []string // Only one of MountPath or
+	DevicePath     []string // DevicePath should be specified.
 }
 
 func (c *CreatePodArgs) Validate() error {
 	if (c.GenerateName == "" && c.Name == "") ||
 		(c.GenerateName != "" && c.Name != "") ||
-		(c.MountPath == "" && c.DevicePath == "") ||
-		(c.MountPath != "" && c.DevicePath != "") ||
-		c.PVCName == "" || c.Namespace == "" {
+		(len(c.MountPath) == 0 && len(c.DevicePath) == 0) ||
+		(len(c.MountPath) != 0 && len(c.DevicePath) != 0) ||
+		len(c.PVCName) == 0 || c.Namespace == "" {
 		return fmt.Errorf("Invalid CreatePodArgs (%#v)", c)
 	}
 	return nil


### PR DESCRIPTION
This PR updates the following CreatePodArgs
```
type CreatePodArgs struct {
	Name           string // Only one of Name or
	GenerateName   string // GenerateName should be specified.
	PVCName        string
	Namespace      string
	RunAsUser      int64
	ContainerImage string
	Command        []string
	ContainerArgs  []string
	MountPath      string // Only one of MountPath or
	DevicePath     string // DevicePath should be specified.
}
```
to
```
type CreatePodArgs struct {
	Name           string // Only one of Name or
	GenerateName   string // GenerateName should be specified.
	PVCName        []string
	Namespace      string
	RunAsUser      int64
	ContainerImage string
	Command        []string
	ContainerArgs  []string
	MountPath      []string // Only one of MountPath or
	DevicePath     []string // DevicePath should be specified.
}
```

Inorder to allow mounting multiple PVCs on the inspector pod