### PR TITLE
Fixing the volume mount names in CreatePod function

### DIFF
--- a/pkg/csi/csi_ops.go
+++ b/pkg/csi/csi_ops.go
@@ -210,9 +210,10 @@ func (c *applicationCreate) CreatePod(ctx context.Context, args *types.CreatePod
 			}},
 		},
 	}
+	pvcCount := 1
 	for pvcName, path := range args.PVCMap {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-			Name: fmt.Sprintf("%s-%s", volumeNameInPod, pvcName),
+			Name: fmt.Sprintf("%s-%d", volumeNameInPod, pvcCount),
 			VolumeSource: v1.VolumeSource{
 				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 					ClaimName: pvcName,
@@ -221,15 +222,16 @@ func (c *applicationCreate) CreatePod(ctx context.Context, args *types.CreatePod
 		})
 		if len(path.MountPath) != 0 {
 			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-				Name:      fmt.Sprintf("%s-%s", volumeNameInPod, pvcName),
+				Name:      fmt.Sprintf("%s-%d", volumeNameInPod, pvcCount),
 				MountPath: path.MountPath,
 			})
 		} else {
 			pod.Spec.Containers[0].VolumeDevices = append(pod.Spec.Containers[0].VolumeDevices, v1.VolumeDevice{
-				Name:       fmt.Sprintf("%s-%s", volumeNameInPod, pvcName),
+				Name:       fmt.Sprintf("%s-%d", volumeNameInPod, pvcCount),
 				DevicePath: path.DevicePath,
 			})
 		}
+		pvcCount++
 	}
 
 	if args.RunAsUser > 0 {

--- a/pkg/csi/csi_ops_test.go
+++ b/pkg/csi/csi_ops_test.go
@@ -702,22 +702,23 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 			c.Assert(pod.Spec.Containers[0].Command, DeepEquals, tc.args.Command)
 			c.Assert(pod.Spec.Containers[0].Args, DeepEquals, tc.args.ContainerArgs)
 			index := 0
+			pvcCount := 1
 			for pvcName, path := range tc.args.PVCMap {
 				if len(path.MountPath) != 0 {
 					c.Assert(pod.Spec.Containers[0].VolumeMounts[index], DeepEquals, v1.VolumeMount{
-						Name:      fmt.Sprintf("persistent-storage-%s", pvcName),
+						Name:      fmt.Sprintf("persistent-storage-%d", pvcCount),
 						MountPath: path.MountPath,
 					})
 					c.Assert(pod.Spec.Containers[0].VolumeDevices, IsNil)
 				} else {
 					c.Assert(pod.Spec.Containers[0].VolumeDevices[index], DeepEquals, v1.VolumeDevice{
-						Name:       fmt.Sprintf("persistent-storage-%s", pvcName),
+						Name:       fmt.Sprintf("persistent-storage-%d", pvcCount),
 						DevicePath: path.DevicePath,
 					})
 					c.Assert(pod.Spec.Containers[0].VolumeMounts, IsNil)
 				}
 				c.Assert(pod.Spec.Volumes[index], DeepEquals, v1.Volume{
-					Name: fmt.Sprintf("persistent-storage-%s", pvcName),
+					Name: fmt.Sprintf("persistent-storage-%d", pvcCount),
 					VolumeSource: v1.VolumeSource{
 						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 							ClaimName: pvcName,
@@ -725,6 +726,7 @@ func (s *CSITestSuite) TestCreatePod(c *C) {
 					},
 				})
 				index++
+				pvcCount++
 			}
 			if tc.args.ContainerImage == "" {
 				c.Assert(pod.Spec.Containers[0].Image, Equals, common.DefaultPodImage)


### PR DESCRIPTION
This PR fixes errors that could occur in case the pod names and/or volume names exceed 64 character limit .