### PR TITLE
Resource name shortner fixed #295

### DIFF
--- a/pkg/block/block_mount.go
+++ b/pkg/block/block_mount.go
@@ -76,8 +76,8 @@ func NewBlockMountChecker(args BlockMountCheckerArgs) (BlockMountChecker, error)
 
 	b := &blockMountChecker{}
 	b.args = args
-	b.podName = fmt.Sprintf(blockMountCheckerPodNameFmt, b.args.StorageClass)
-	b.pvcName = fmt.Sprintf(blockMountCheckerPVCNameFmt, b.args.StorageClass)
+	b.podName = ResourceNameShortener(fmt.Sprintf(blockMountCheckerPodNameFmt, b.args.StorageClass))
+	b.pvcName = ResourceNameShortener(fmt.Sprintf(blockMountCheckerPVCNameFmt, b.args.StorageClass))
 	b.validator = csi.NewArgumentValidator(b.args.KubeCli, b.args.DynCli)
 	b.appCreator = csi.NewApplicationCreator(b.args.KubeCli, args.K8sObjectReadyTimeout)
 	b.cleaner = csi.NewCleaner(b.args.KubeCli, b.args.DynCli)

--- a/pkg/block/helper.go
+++ b/pkg/block/helper.go
@@ -8,7 +8,7 @@ import (
 // resource name maxs lenght
 const maxResourceNameLength = 64
 
-// ResourceNameShortener shortens the resource name if it exceeds maxResourceNameLength.
+// ResourceNameShortener shortens the resource name if it exceeds maxResourceNameLength of 64.
 // It replaces the last 5 characters with the first 5 characters of a hash (base64 encoded).
 func ResourceNameShortener(name string) string {
 	if len(name) <= maxResourceNameLength {

--- a/pkg/block/helper.go
+++ b/pkg/block/helper.go
@@ -1,0 +1,28 @@
+package block
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// resource name maxs lenght
+const maxResourceNameLength = 64
+
+// ResourceNameShortener shortens the resource name if it exceeds maxResourceNameLength.
+// It replaces the last 5 characters with the first 5 characters of a hash (base64 encoded).
+func ResourceNameShortener(name string) string {
+	if len(name) <= maxResourceNameLength {
+		return name
+	}
+
+	// Create a SHA-256 hash of the name
+	hash := sha256.Sum256([]byte(name))
+
+	// Convert the hash to a base64 string
+	hashBase64 := base64.RawURLEncoding.EncodeToString(hash[:])
+
+	// Truncate the name and replace the last 5 characters with the first 5 characters of the hash
+	truncatedName := name[:maxResourceNameLength-6] + "-" + hashBase64[:5]
+
+	return truncatedName
+}

--- a/pkg/block/helper_test.go
+++ b/pkg/block/helper_test.go
@@ -1,0 +1,39 @@
+package block
+
+import (
+	"testing"
+)
+
+// TestShortenResourceName tests different variations of the ephemeral resource name.
+func TestResourceNameShortener(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int // We will check the length of the output
+	}{
+		{
+			name:     "Short name (less than 64 characters)",
+			input:    "ephemeral-persistent-volume-claim",
+			expected: len("ephemeral-persistent-volume-claim"),
+		},
+		{
+			name:     "Exact 64 characters",
+			input:    "ephemeral-persistent-volume-claim-for-application-persistent-volume-clai",
+			expected: 64,
+		},
+		{
+			name:     "Name longer than 64 characters",
+			input:    "ephemeral-persistent-volume-claim-for-application-persistent-volume-claim",
+			expected: 64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResourceNameShortener(tt.input)
+			if len(got) != tt.expected {
+				t.Errorf("ShortenResourceName() = %v (length %d), expected length %d", got, len(got), tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changes

fixed #295 ResourceNameShortener shortens the resource name if it exceeds maxResourceNameLength of 64

- Added `ResourceNameShortener` function to handle name shortening.
- Updated existing commands to use the helper function.
- Added tests for various cases, including names longer than 64 characters.

### References

Fixes #123