### PR TITLE
Refactoring the file-restore command to use a --fromPVC arg

### DIFF
--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -231,6 +231,8 @@ func init() {
 	rootCmd.AddCommand(restoreFileCmd)
 	restoreFileCmd.Flags().StringVarP(&fromSnapshot, "fromSnapshot", "f", "", "The name of a VolumeSnapshot.")
 	restoreFileCmd.Flags().StringVarP(&fromPVC, "fromPVC", "v", "", "The name of a PersistentVolumeClaim.")
+	restoreFileCmd.MarkFlagsMutuallyExclusive("fromSnapshot", "fromPVC")
+	restoreFileCmd.MarkFlagsOneRequired("fromSnapshot", "fromPVC")
 	restoreFileCmd.Flags().StringVarP(&toPVC, "toPVC", "t", "", "The name of a PersistentVolumeClaim.")
 	restoreFileCmd.Flags().StringVarP(&namespace, "namespace", "n", fio.DefaultNS, "The namespace of both the given PVC & VS.")
 	restoreFileCmd.Flags().Int64VarP(&csiCheckRunAsUser, "runAsUser", "u", 0, "Runs the inspector pod as a user (int)")

--- a/pkg/csi/file_restore_inspector.go
+++ b/pkg/csi/file_restore_inspector.go
@@ -171,7 +171,7 @@ func (f *fileRestoreSteps) ValidateArgs(ctx context.Context, args *types.FileRes
 		if err != nil {
 			return nil, nil, nil, nil, errors.Wrap(err, "Failed to validate source PVC")
 		}
-		sc, err = f.validateOps.ValidateStorageClass(ctx, *restorePVC.Spec.StorageClassName)
+		_, err = f.validateOps.ValidateStorageClass(ctx, *restorePVC.Spec.StorageClassName)
 		if err != nil {
 			return nil, nil, nil, nil, errors.Wrap(err, "Failed to validate StorageClass for restore PVC")
 		}

--- a/pkg/csi/file_restore_inspector_test.go
+++ b/pkg/csi/file_restore_inspector_test.go
@@ -39,10 +39,10 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			prepare: func(f *fields) {
 				gomock.InOrder(
 					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(
-						&snapv1.VolumeSnapshot{}, &v1.PersistentVolumeClaim{}, &sv1.StorageClass{}, nil,
+						&snapv1.VolumeSnapshot{}, &v1.PersistentVolumeClaim{}, &v1.PersistentVolumeClaim{}, &sv1.StorageClass{}, nil,
 					),
 					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(),
-						&snapv1.VolumeSnapshot{}, &v1.PersistentVolumeClaim{}, &sv1.StorageClass{},
+						&snapv1.VolumeSnapshot{}, &v1.PersistentVolumeClaim{}, &v1.PersistentVolumeClaim{}, &sv1.StorageClass{},
 					).Return(
 						&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -66,7 +66,7 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 							},
 						}, gomock.Any(),
 					).Return(nil),
-					f.stepperOps.EXPECT().Cleanup(gomock.Any(),
+					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(),
 						&v1.PersistentVolumeClaim{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "pvc1",
@@ -91,10 +91,10 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			args:    &types.FileRestoreArgs{},
 			prepare: func(f *fields) {
 				gomock.InOrder(
-					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil),
-					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil),
+					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil, nil),
+					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil),
 					f.stepperOps.EXPECT().PortForwardAPod(gomock.Any(), gomock.Any()).Return(fmt.Errorf("portforward error")),
-					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any()),
+					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
 			},
 			errChecker: NotNil,
@@ -106,9 +106,9 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			args:    &types.FileRestoreArgs{},
 			prepare: func(f *fields) {
 				gomock.InOrder(
-					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil),
-					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("createapp error")),
-					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any()),
+					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil, nil),
+					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("createapp error")),
+					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
 			},
 			errChecker: NotNil,
@@ -120,8 +120,8 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			args:    &types.FileRestoreArgs{},
 			prepare: func(f *fields) {
 				gomock.InOrder(
-					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, fmt.Errorf("snapshot error")),
-					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any()),
+					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil, fmt.Errorf("snapshot error")),
+					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
 			},
 			errChecker: NotNil,
@@ -133,8 +133,8 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			args:    &types.FileRestoreArgs{},
 			prepare: func(f *fields) {
 				gomock.InOrder(
-					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, fmt.Errorf("validate error")),
-					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any()),
+					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil, fmt.Errorf("validate error")),
+					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
 			},
 			errChecker: NotNil,
@@ -146,7 +146,7 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			args:    &types.FileRestoreArgs{},
 			prepare: func(f *fields) {
 				gomock.InOrder(
-					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any()),
+					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
 			},
 			errChecker: NotNil,
@@ -158,7 +158,7 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			args:    &types.FileRestoreArgs{},
 			prepare: func(f *fields) {
 				gomock.InOrder(
-					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any()),
+					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
 			},
 			errChecker: NotNil,
@@ -187,6 +187,7 @@ func (s *CSITestSuite) TestFileRestoreRunner(c *C) {
 	r := &FileRestoreRunner{
 		restoreSteps: &fileRestoreSteps{},
 	}
-	err := r.RunFileRestoreHelper(ctx, nil)
+	args := types.FileRestoreArgs{}
+	err := r.RunFileRestoreHelper(ctx, &args)
 	c.Check(err, NotNil)
 }

--- a/pkg/csi/mocks/mock_file_restore_stepper.go
+++ b/pkg/csi/mocks/mock_file_restore_stepper.go
@@ -39,21 +39,21 @@ func (m *MockFileRestoreStepper) EXPECT() *MockFileRestoreStepperMockRecorder {
 }
 
 // Cleanup mocks base method.
-func (m *MockFileRestoreStepper) Cleanup(arg0 context.Context, arg1 *v10.PersistentVolumeClaim, arg2 *v10.Pod) {
+func (m *MockFileRestoreStepper) Cleanup(arg0 context.Context, arg1 *types.FileRestoreArgs, arg2 *v10.PersistentVolumeClaim, arg3 *v10.Pod) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Cleanup", arg0, arg1, arg2)
+	m.ctrl.Call(m, "Cleanup", arg0, arg1, arg2, arg3)
 }
 
 // Cleanup indicates an expected call of Cleanup.
-func (mr *MockFileRestoreStepperMockRecorder) Cleanup(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockFileRestoreStepperMockRecorder) Cleanup(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockFileRestoreStepper)(nil).Cleanup), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockFileRestoreStepper)(nil).Cleanup), arg0, arg1, arg2, arg3)
 }
 
 // CreateInspectorApplication mocks base method.
-func (m *MockFileRestoreStepper) CreateInspectorApplication(arg0 context.Context, arg1 *types.FileRestoreArgs, arg2 *v1.VolumeSnapshot, arg3 *v10.PersistentVolumeClaim, arg4 *v11.StorageClass) (*v10.Pod, *v10.PersistentVolumeClaim, error) {
+func (m *MockFileRestoreStepper) CreateInspectorApplication(arg0 context.Context, arg1 *types.FileRestoreArgs, arg2 *v1.VolumeSnapshot, arg3, arg4 *v10.PersistentVolumeClaim, arg5 *v11.StorageClass) (*v10.Pod, *v10.PersistentVolumeClaim, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateInspectorApplication", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "CreateInspectorApplication", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*v10.Pod)
 	ret1, _ := ret[1].(*v10.PersistentVolumeClaim)
 	ret2, _ := ret[2].(error)
@@ -61,9 +61,9 @@ func (m *MockFileRestoreStepper) CreateInspectorApplication(arg0 context.Context
 }
 
 // CreateInspectorApplication indicates an expected call of CreateInspectorApplication.
-func (mr *MockFileRestoreStepperMockRecorder) CreateInspectorApplication(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockFileRestoreStepperMockRecorder) CreateInspectorApplication(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInspectorApplication", reflect.TypeOf((*MockFileRestoreStepper)(nil).CreateInspectorApplication), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInspectorApplication", reflect.TypeOf((*MockFileRestoreStepper)(nil).CreateInspectorApplication), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // ExecuteCopyCommand mocks base method.
@@ -96,14 +96,15 @@ func (mr *MockFileRestoreStepperMockRecorder) PortForwardAPod(arg0, arg1 interfa
 }
 
 // ValidateArgs mocks base method.
-func (m *MockFileRestoreStepper) ValidateArgs(arg0 context.Context, arg1 *types.FileRestoreArgs) (*v1.VolumeSnapshot, *v10.PersistentVolumeClaim, *v11.StorageClass, error) {
+func (m *MockFileRestoreStepper) ValidateArgs(arg0 context.Context, arg1 *types.FileRestoreArgs) (*v1.VolumeSnapshot, *v10.PersistentVolumeClaim, *v10.PersistentVolumeClaim, *v11.StorageClass, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateArgs", arg0, arg1)
 	ret0, _ := ret[0].(*v1.VolumeSnapshot)
 	ret1, _ := ret[1].(*v10.PersistentVolumeClaim)
-	ret2, _ := ret[2].(*v11.StorageClass)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret2, _ := ret[2].(*v10.PersistentVolumeClaim)
+	ret3, _ := ret[3].(*v11.StorageClass)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // ValidateArgs indicates an expected call of ValidateArgs.

--- a/pkg/csi/types/csi_types.go
+++ b/pkg/csi/types/csi_types.go
@@ -163,16 +163,23 @@ func (p *SnapshotBrowseArgs) Validate() error {
 }
 
 type FileRestoreArgs struct {
-	SnapshotName string
-	PVCName      string
-	Namespace    string
-	RunAsUser    int64
-	LocalPort    int
-	Path         string
+	FromSnapshotName string
+	FromPVCName      string
+	ToPVCName        string
+	Namespace        string
+	RunAsUser        int64
+	LocalPort        int
+	Path             string
 }
 
 func (f *FileRestoreArgs) Validate() error {
-	if f.SnapshotName == "" || f.Namespace == "" {
+	if (f.FromSnapshotName == "" && f.FromPVCName == "") || (f.FromSnapshotName != "" && f.FromPVCName != "") {
+		return fmt.Errorf("Either --fromSnapshot or --fromPVC argument must be specified. Both cannot be specified together.")
+	}
+	if f.FromPVCName != "" && f.ToPVCName == "" {
+		return fmt.Errorf("--toPVC argument must be specified if using --fromPVC.")
+	}
+	if f.Namespace == "" {
 		return fmt.Errorf("Invalid FileRestoreArgs (%v)", f)
 	}
 	return nil


### PR DESCRIPTION
This PR adds a --fromPVC argument to the `./kubestr file-restore` command. It would help users to mount a backup PVC along with their application PVC to a browser pod instead of only relying on a VolumeSnapshot as a backup.

Unit-tested these code changes with new fake tests and mock objects.
Tested these code changes by executing the command on a GKE cluster. Please find the output below;

```
> ./bin/kubestr file-restore --fromPVC single-file-pvc --toPVC dummy-app-pvc -n application
Fetching the snapshot or PVC.
Fetching the restore PVC.
Fetching the source PVC.
Creating the browser pod & mounting the PVCs.
Forwarding the port.
Port forwarding is ready to get traffic. visit http://localhost:8080/
^C
Stopping port forward.
Cleaning up browser pod.
```

During cleanup, we do not clean the PVC. We just delete the Filebrowser pod.