### PR TITLE
Fixing errors in --path flag for kubestr file-restore

### DIFF
--- a/pkg/csi/file_restore_inspector_steps_test.go
+++ b/pkg/csi/file_restore_inspector_steps_test.go
@@ -618,7 +618,7 @@ func (s *CSITestSuite) TestCreateInspectorApplicationForFileRestore(c *C) {
 				},
 			},
 		}
-		pod, pvc, err := stepper.CreateInspectorApplication(ctx, tc.args, tc.fromSnapshot, tc.fromPVC, &sourcePVC, tc.sc)
+		pod, pvc, _, err := stepper.CreateInspectorApplication(ctx, tc.args, tc.fromSnapshot, tc.fromPVC, &sourcePVC, tc.sc)
 		c.Check(err, tc.errChecker)
 		c.Check(pod, tc.podChecker)
 		c.Check(pvc, tc.pvcChecker)

--- a/pkg/csi/file_restore_inspector_test.go
+++ b/pkg/csi/file_restore_inspector_test.go
@@ -56,6 +56,7 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 								Namespace: "ns",
 							},
 						},
+						"",
 						nil,
 					),
 					f.stepperOps.EXPECT().PortForwardAPod(
@@ -92,7 +93,7 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			prepare: func(f *fields) {
 				gomock.InOrder(
 					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil, nil),
-					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil),
+					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, "", nil),
 					f.stepperOps.EXPECT().PortForwardAPod(gomock.Any(), gomock.Any()).Return(fmt.Errorf("portforward error")),
 					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
@@ -107,7 +108,7 @@ func (s *CSITestSuite) TestRunFileRestoreHelper(c *C) {
 			prepare: func(f *fields) {
 				gomock.InOrder(
 					f.stepperOps.EXPECT().ValidateArgs(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil, nil),
-					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("createapp error")),
+					f.stepperOps.EXPECT().CreateInspectorApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, "", fmt.Errorf("createapp error")),
 					f.stepperOps.EXPECT().Cleanup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()),
 				)
 			},

--- a/pkg/csi/mocks/mock_file_restore_stepper.go
+++ b/pkg/csi/mocks/mock_file_restore_stepper.go
@@ -51,13 +51,14 @@ func (mr *MockFileRestoreStepperMockRecorder) Cleanup(arg0, arg1, arg2, arg3 int
 }
 
 // CreateInspectorApplication mocks base method.
-func (m *MockFileRestoreStepper) CreateInspectorApplication(arg0 context.Context, arg1 *types.FileRestoreArgs, arg2 *v1.VolumeSnapshot, arg3, arg4 *v10.PersistentVolumeClaim, arg5 *v11.StorageClass) (*v10.Pod, *v10.PersistentVolumeClaim, error) {
+func (m *MockFileRestoreStepper) CreateInspectorApplication(arg0 context.Context, arg1 *types.FileRestoreArgs, arg2 *v1.VolumeSnapshot, arg3, arg4 *v10.PersistentVolumeClaim, arg5 *v11.StorageClass) (*v10.Pod, *v10.PersistentVolumeClaim, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInspectorApplication", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*v10.Pod)
 	ret1, _ := ret[1].(*v10.PersistentVolumeClaim)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // CreateInspectorApplication indicates an expected call of CreateInspectorApplication.
@@ -67,18 +68,18 @@ func (mr *MockFileRestoreStepperMockRecorder) CreateInspectorApplication(arg0, a
 }
 
 // ExecuteCopyCommand mocks base method.
-func (m *MockFileRestoreStepper) ExecuteCopyCommand(arg0 context.Context, arg1 *types.FileRestoreArgs, arg2 *v10.Pod) (string, error) {
+func (m *MockFileRestoreStepper) ExecuteCopyCommand(arg0 context.Context, arg1 *types.FileRestoreArgs, arg2 *v10.Pod, arg3 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecuteCopyCommand", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ExecuteCopyCommand", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExecuteCopyCommand indicates an expected call of ExecuteCopyCommand.
-func (mr *MockFileRestoreStepperMockRecorder) ExecuteCopyCommand(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockFileRestoreStepperMockRecorder) ExecuteCopyCommand(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteCopyCommand", reflect.TypeOf((*MockFileRestoreStepper)(nil).ExecuteCopyCommand), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteCopyCommand", reflect.TypeOf((*MockFileRestoreStepper)(nil).ExecuteCopyCommand), arg0, arg1, arg2, arg3)
 }
 
 // PortForwardAPod mocks base method.


### PR DESCRIPTION
This PR fixes improper --path handling in `kubestr file-restore` command. 
Basically, the command failed to execute the POSIX copy command in the browser pod because the root directory of source path passed to the command was not the root directory of the mount path on the browser pod.