### PR TITLE
Exclude default annotation on volume snapshot class clone

### DIFF
--- a/pkg/csi/csi_ops.go
+++ b/pkg/csi/csi_ops.go
@@ -40,6 +40,9 @@ const (
 
 	PVCKind = "PersistentVolumeClaim"
 	PodKind = "Pod"
+
+	// DefaultVolumeSnapshotClassAnnotation is an annotation used to denote a default VolumeSnapshotClass.
+	DefaultVolumeSnapshotClassAnnotation = "snapshot.storage.kubernetes.io/is-default-class"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination=mocks/mock_argument_validator.go -package=mocks . ArgumentValidator
@@ -405,7 +408,7 @@ func (c *snapshotCreate) CreateFromSourceCheck(ctx context.Context, snapshotter 
 		return err
 	}
 	targetSnapClassName := clonePrefix + args.VolumeSnapshotClass
-	err := snapshotter.CloneVolumeSnapshotClass(ctx, args.VolumeSnapshotClass, targetSnapClassName, kansnapshot.DeletionPolicyRetain, nil)
+	err := snapshotter.CloneVolumeSnapshotClass(ctx, args.VolumeSnapshotClass, targetSnapClassName, kansnapshot.DeletionPolicyRetain, []string{DefaultVolumeSnapshotClassAnnotation})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to clone a VolumeSnapshotClass to use to restore the snapshot")
 	}


### PR DESCRIPTION
The (now deprecated) snapshot validating webhook for volumesnapshotclasses.snapshot.storage.k8s.io does not accept if there is more than one VSC with the default annotation `snapshot.storage.kubernetes.io/is-default-class`. This PR excludes it when cloning a VSC.

The webhook in question: https://github.com/kubernetes-csi/external-snapshotter/tree/release-8.1/deploy/kubernetes/webhook-example

Manually verified on OCP 4.16 environment where the webhook is present.