### PR TITLE
add version command to kubestr

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
   - env:
       - CGO_ENABLED=0
       - GO_EXTLINK_ENABLED=0
+    ldflags:
+      - -X github.com/kastenhq/kubestr/cmd.version={{.Version}}
     goos:
       - linux
       - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
       - CGO_ENABLED=0
       - GO_EXTLINK_ENABLED=0
     ldflags:
-      - -X github.com/kastenhq/kubestr/cmd.version={{.Version}}
+      - -X github.com/kastenhq/kubestr/cmd.version=v{{ trimprefix .Version "v" }}
     goos:
       - linux
       - windows

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/kastenhq/kubestr/pkg/block"
@@ -30,6 +31,8 @@ import (
 )
 
 var (
+	version = "dev" // overridden at build time via ldflags
+
 	output  string
 	outfile string
 	rootCmd = &cobra.Command{
@@ -154,7 +157,15 @@ var (
 	blockMountCleanupOnly        bool
 	blockMountWaitTimeoutSeconds uint32
 	blockMountPVCSize            string
-	blockMountCmd                = &cobra.Command{
+	versionCmd                   = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version of kubestr",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(GetVersion())
+		},
+	}
+
+	blockMountCmd = &cobra.Command{
 		Use:   "blockmount",
 		Short: "Checks if a storage class supports block volumes",
 		Long: `Checks if volumes provisioned by a storage class can be mounted in block mode.
@@ -193,6 +204,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "Options(json)")
 	rootCmd.PersistentFlags().StringVarP(&outfile, "outfile", "e", "", "The file where test results will be written")
 
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(fioCmd)
 	fioCmd.Flags().StringVarP(&storageClass, "storageclass", "s", "", "The name of a Storageclass. (Required)")
 	_ = fioCmd.MarkFlagRequired("storageclass")
@@ -547,4 +559,44 @@ func BlockMountCheck(ctx context.Context, output, outfile string, cleanupOnly bo
 	}
 
 	return err
+}
+
+// GetVersion returns the version of kubestr.
+// If the version was injected at build time via ldflags by goreleaser, it returns that.
+// Otherwise, it falls back to reading the git commit hash that Go automatically
+// bakes into the binary since Go 1.18 (see runtime/debug.BuildSetting).
+func GetVersion() string {
+	// version is set at build time via ldflags by goreleaser (e.g. v0.4.49).
+	// If it was injected, return it.
+	if version != "dev" {
+		return version
+	}
+	// For binaries built with `go build .`, the Go toolchain automatically
+	// embeds VCS info (commit SHA, dirty state) since Go 1.18. Read it back
+	// here as a fallback so dev builds still report something useful.
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		// No build info available (e.g. built outside a git repo).
+		return "dev"
+	}
+	var revision, modified string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			// Use the short 7-character SHA, matching the `git log --oneline` format.
+			if len(s.Value) >= 7 {
+				revision = s.Value[:7]
+			}
+		case "vcs.modified":
+			// Append -dirty if the working tree had uncommitted changes at build time.
+			if s.Value == "true" {
+				modified = "-dirty"
+			}
+		}
+	}
+	if revision != "" {
+		return fmt.Sprintf("dev (%s%s)", revision, modified)
+	}
+	// Git repo exists but VCS info was not embedded (e.g. -buildvcs=false was passed).
+	return "dev"
 }

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -160,8 +160,9 @@ var (
 	versionCmd                   = &cobra.Command{
 		Use:   "version",
 		Short: "Print the version of kubestr",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(GetVersion())
+			cmd.Println(GetVersion())
 		},
 	}
 

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	version = "dev" // overridden at build time via ldflags
+	version string // overridden at build time via ldflags
 
 	output  string
 	outfile string
@@ -162,7 +162,7 @@ var (
 		Short: "Print the version of kubestr",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Println(GetVersion())
+			cmd.Println(getVersion())
 		},
 	}
 
@@ -562,14 +562,14 @@ func BlockMountCheck(ctx context.Context, output, outfile string, cleanupOnly bo
 	return err
 }
 
-// GetVersion returns the version of kubestr.
+// getVersion returns the version of kubestr.
 // If the version was injected at build time via ldflags by goreleaser, it returns that.
 // Otherwise, it falls back to reading the git commit hash that Go automatically
 // bakes into the binary since Go 1.18 (see runtime/debug.BuildSetting).
-func GetVersion() string {
+func getVersion() string {
 	// version is set at build time via ldflags by goreleaser (e.g. v0.4.49).
 	// If it was injected, return it.
-	if version != "dev" {
+	if version != "" {
 		return version
 	}
 	// For binaries built with `go build .`, the Go toolchain automatically
@@ -596,7 +596,7 @@ func GetVersion() string {
 		}
 	}
 	if revision != "" {
-		return fmt.Sprintf("dev (%s%s)", revision, modified)
+		return fmt.Sprintf("dev-%s%s", revision, modified)
 	}
 	// Git repo exists but VCS info was not embedded (e.g. -buildvcs=false was passed).
 	return "dev"

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -160,7 +160,7 @@ var (
 	versionCmd                   = &cobra.Command{
 		Use:   "version",
 		Short: "Print the version of kubestr",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(getVersion())
 		},

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -578,7 +578,7 @@ func getVersion() string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		// No build info available (e.g. built outside a git repo).
-		return "dev"
+		return "unknown"
 	}
 	var revision, modified string
 	for _, s := range info.Settings {
@@ -599,5 +599,5 @@ func getVersion() string {
 		return fmt.Sprintf("dev-%s%s", revision, modified)
 	}
 	// Git repo exists but VCS info was not embedded (e.g. -buildvcs=false was passed).
-	return "dev"
+	return "unknown"
 }

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -162,7 +162,7 @@ var (
 		Short: "Print the version of kubestr",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Println(getVersion())
+			fmt.Println(getVersion())
 		},
 	}
 


### PR DESCRIPTION
- Addresses #138

This PR adds a `version` command to kubestr.

It does two things:

1. Adds a `version` variable to `cmd/rootCmd.go` that defaults to `"dev"` and gets overwritten at build time via `-ldflags` when goreleaser builds an official release
2. For binaries built from source with `go build .`, falls back to reading the git commit hash that Go automatically bakes into the binary since Go 1.18 (see [`runtime/debug.BuildSetting`](https://pkg.go.dev/runtime/debug#BuildSetting)) — this way dev builds still show something useful. A `-dirty` suffix is appended if there were uncommitted changes at build time, following the convention established by `git describe --dirty`

The behavior looks like this depending on how the binary was built:

```
# Official release binary (built by goreleaser)
$ kubestr version
v0.4.49

# Built from source at a clean commit
$ kubestr version
dev (0157133)

# Built from source with uncommitted changes
$ kubestr version
dev (0157133-dirty)

# Built outside a git repo (e.g. from a source tarball)
$ kubestr version
dev
```

Unfortunately there is no single approach that works for all cases since go build and go install behave differently with respect to version stamping. The hybrid approach here covers all realistic scenarios without requiring changes to the release pipeline beyond adding the -X ldflag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new version command that prints the current build version.
  * Builds now embed a release version string so the version command shows the injected release version; if no injected version is present, it falls back to a development label containing a short VCS revision and a “dirty” marker when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->