### PR TITLE
build(deps): upgrade Go to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kastenhq/kubestr
 
-go 1.24
+go 1.25
 
 replace github.com/graymeta/stow => github.com/kastenhq/stow v0.1.2-kasten
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->