### PR TITLE
build(ci): upgrade golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,6 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v2.2.1
+          version: v2.12.2
           args: --timeout=5m --modules-download-mode=mod
           skip-cache: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code-quality checks to use a newer linting tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->